### PR TITLE
fix rDNS

### DIFF
--- a/asn
+++ b/asn
@@ -61,10 +61,9 @@ TraceASPath(){
         echo -en "$collecting_message"
         # fetch raw mtr results beginning with :
         # - h ("hostline", or IPs) 
-        # - d ("dnsline", or hostnames)
         # - p ("pingline", or latencies)
         # see https://github.com/traviscross/mtr/blob/master/FORMATS
-        mtr_output=$(mtr -l -c"$mtr_rounds" "$host_to_trace" | grep "^[hdp]")
+        mtr_output=$(mtr -l -n -c"$mtr_rounds" "$host_to_trace" | grep "^[hp]")
         declare -a hostline_array
         declare -a dnsline_array
         declare -a pingline_array
@@ -81,10 +80,10 @@ TraceASPath(){
                         "h")
                                 # this is a hostline ($mtr_data is an IP address)
                                 hostline_array["$mtr_hopnum"]="$mtr_data"
-                                ;;
-                        "d")
-                                # this is a dnsline ($mtr_data is a hostname)
-                                dnsline_array["$mtr_hopnum"]="$mtr_data"
+                                rdns=$(host "$mtr_data")
+                                if [ $? == 0 ]; then
+                                        dnsline_array["$mtr_hopnum"]=$(echo $rdns | awk '{print $NF}')
+                                fi
                                 ;;
                         "p")
                                 # this is a pingline ($mtr_data is a latency value in microseconds)


### PR DESCRIPTION
The rDNS lookup wasnt working for me because mtr doesnt return the hostnames in -l mode (because of latency i guess?).
With this patch its working for me. Please tell me what you think about it.

Without patch:
![07-08-2020_21 05 21_89b1353e8e6270077f5ae106f401bfcc](https://user-images.githubusercontent.com/6840978/89680074-87305b80-d8f2-11ea-98e9-e963e4ce9e67.png)
With patch:
![07-08-2020_21 06 58_8e147127feebd4ef680b88c2b28716c9](https://user-images.githubusercontent.com/6840978/89680042-7da6f380-d8f2-11ea-983f-545eced7d11f.png)

btw this is a really great tool