### PR TITLE
multiple rDNS answers fix

### DIFF
--- a/asn
+++ b/asn
@@ -92,7 +92,7 @@ TraceASPath(){
                                                 last_resolved_ip="$mtr_data"
                                                 if hostname=$(host "$mtr_data"); then
                                                         dnsline_array["$mtr_hopnum"]=$(echo "$hostname" |\
-                                                        awk '{sub(/\.\r?$/, "", $NF); print $NF}') # remove trailing dot and CR (Cygwin) from hostname
+                                                        awk 'NR==1{sub(/\.\r?$/, "", $NF); print $NF}') # get first line and remove trailing dot and CR (Cygwin) from hostname
                                                 fi
                                         fi
                                         ;;


### PR DESCRIPTION
Your speedup is great but i noticed a small issue when having multiple rDNS answers, which is rare but possible, the output of `asn` is quite ugly in my opinion.
I think its ok to just show the first result.

without patch:
![09-08-2020_13 40 37_1d5cf7a337c5b3c9d9ca897aa80bf924](https://user-images.githubusercontent.com/6840978/89731455-6c233000-da47-11ea-94d1-fed719b20302.png)

with patch:
![09-08-2020_13 56 05_61e7502bfa423711c1b8a033c3253cb3](https://user-images.githubusercontent.com/6840978/89731542-26b33280-da48-11ea-9e9a-04029f977f0f.png)
