### PR TITLE
debian-based Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian:12-slim
+
+RUN apt update && \
+    apt upgrade && \
+    apt install -y --no-install-recommends \
+      aha \
+      bash \
+      bind9-dnsutils \
+      curl \
+      grepcidr \
+      ipcalc \
+      jq \
+      mtr-tiny \
+      ncat \
+      ncurses-bin \
+      nmap \
+      whois \
+    && useradd --no-log-init -K UID_MIN=10000 -K GID_MIN=10000 user
+
+RUN mkdir -p /app
+COPY asn /app/asn
+RUN chmod 0755 /app/asn
+
+USER 10000
+EXPOSE 49200/tcp
+ENTRYPOINT ["/app/asn"]
+CMD ["-l", "0.0.0.0"]


### PR DESCRIPTION
This is similar to #51 but resolves a few issues:

 1. doesn't run as the root user by default (this can be changed at runtime of course)
 2. add missing grepcidr dependency

This is based on Debian because that is what I am most familiar with: even though there seems to be a grepcidr3 package in Alpine, I couldn't figure out how to install it in the build.

Closes: #49